### PR TITLE
Fix bug in metric calculation call order

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -104,7 +104,6 @@ df_filtered_current_year = raw_df.loc[mask].copy()
 # --- Calculated Metrics ---
 if 'company_name' not in df_filtered_current_year.columns:
      df_filtered_current_year['company_name'] = 'Company ' + df_filtered_current_year.index.astype(str)
-     df = calculate_metrics(df_filtered_current_year)
 
 def calculate_metrics(df_in):
     """Calculates derived metrics."""


### PR DESCRIPTION
## Summary
- remove premature call to `calculate_metrics` before its definition

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68474a82a2f483299118f12b25296381